### PR TITLE
Close GH 88, change np.float to float

### DIFF
--- a/sora/body/meta.py
+++ b/sora/body/meta.py
@@ -397,7 +397,7 @@ class BaseBody():
         elif isinstance(value, str):
             self._shape = Shape3D(value)
         else:
-            value = np.array(value, ndmin=1, dtype=np.float)
+            value = np.array(value, ndmin=1, dtype=float)
             if len(value) <= 3:
                 self._shape = Ellipsoid(*value)
             else:


### PR DESCRIPTION
np.float is deprecated and no longer supported in current versions of numpy. Using np.float raises an error. Closes GH 